### PR TITLE
Add DALL·E image generation endpoint and UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,11 +1,16 @@
 import os
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, render_template
 import openai
 
 # Configure OpenAI API key from environment variable
 openai.api_key = os.environ.get("OPENAI_API_KEY")
 
 app = Flask(__name__)
+
+@app.route('/')
+def index():
+    """Render the homepage with the simple form."""
+    return render_template('index.html')
 
 @app.route('/generate', methods=['POST'])
 def generate():
@@ -22,6 +27,21 @@ def generate():
     except Exception as e:
         return jsonify({'error': str(e)}), 500
     return jsonify({'result': result_text})
+
+
+@app.route('/generate-image', methods=['POST'])
+def generate_image():
+    """Generate an image using DALL·E and return its URL."""
+    data = request.get_json(silent=True)
+    if not data or 'prompt' not in data:
+        return jsonify({'error': 'Missing prompt'}), 400
+    prompt = data['prompt']
+    try:
+        response = openai.Image.create(prompt=prompt, n=1, size="512x512")
+        image_url = response['data'][0]['url']
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+    return jsonify({'image_url': image_url})
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Générateur d'images</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        #promptInput { width: 300px; padding: 8px; }
+        #generateBtn { padding: 8px 12px; margin-left: 8px; }
+        #resultImage { display: block; margin-top: 20px; max-width: 512px; }
+    </style>
+</head>
+<body>
+    <h1>Générateur d'images DALL·E</h1>
+    <input type="text" id="promptInput" placeholder="Décrivez l'image" />
+    <button id="generateBtn">Générer une image</button>
+    <img id="resultImage" src="" alt="Image générée" />
+
+    <script>
+        document.getElementById('generateBtn').addEventListener('click', async () => {
+            const prompt = document.getElementById('promptInput').value;
+            if (!prompt) return;
+            const response = await fetch('/generate-image', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ prompt })
+            });
+            if (response.ok) {
+                const data = await response.json();
+                document.getElementById('resultImage').src = data.image_url;
+            }
+        });
+    </script>
+</body>
+</html>

--- a/test_app.py
+++ b/test_app.py
@@ -24,5 +24,16 @@ class GenerateEndpointTestCase(unittest.TestCase):
         self.assertIn('result', data)
         self.assertEqual(data['result'], 'Voici une réponse générée')
 
+    @patch('app.openai.Image.create')
+    def test_generate_image_endpoint(self, mock_image_create):
+        mock_image_create.return_value = {
+            'data': [{'url': 'http://example.com/image.png'}]
+        }
+        response = self.client.post('/generate-image', json={'prompt': 'un chat'})
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertIn('image_url', data)
+        self.assertEqual(data['image_url'], 'http://example.com/image.png')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- build a small HTML interface for image generation
- add `generate-image` endpoint using OpenAI's DALL·E API
- serve index.html from new root route
- test the new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d070e081c832a8465c65d9530f360