### PR TITLE
Fix image generation endpoint error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,13 +33,24 @@ def generate():
 def generate_image():
     """Generate an image using DALL·E and return its URL."""
     data = request.get_json(silent=True)
-    if not data or 'prompt' not in data:
-        return jsonify({'error': 'Missing prompt'}), 400
-    prompt = data['prompt']
+    if not data or 'prompt' not in data or not isinstance(data['prompt'], str):
+        return jsonify({'error': 'Missing or invalid prompt'}), 400
+    prompt = data['prompt'].strip()
+    print(f"Received prompt: {prompt}")
+
+    if not openai.api_key:
+        return jsonify({'error': 'OpenAI API key is not configured'}), 500
+
     try:
         response = openai.Image.create(prompt=prompt, n=1, size="512x512")
-        image_url = response['data'][0]['url']
+        print(f"DALL·E response: {response}")
+        if not response or 'data' not in response or not response['data']:
+            return jsonify({'error': 'Empty response from OpenAI'}), 500
+        image_url = response['data'][0].get('url')
+        if not image_url:
+            return jsonify({'error': 'No image URL returned'}), 500
     except Exception as e:
+        print(f"Error generating image: {e}")
         return jsonify({'error': str(e)}), 500
     return jsonify({'image_url': image_url})
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,7 @@
     <h1>Générateur d'images DALL·E</h1>
     <input type="text" id="promptInput" placeholder="Décrivez l'image" />
     <button id="generateBtn">Générer une image</button>
+    <div id="errorMsg" style="color: red; margin-top: 10px;"></div>
     <img id="resultImage" src="" alt="Image générée" />
 
     <script>
@@ -25,9 +26,15 @@
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ prompt })
             });
+            const errorDiv = document.getElementById('errorMsg');
             if (response.ok) {
                 const data = await response.json();
+                errorDiv.textContent = '';
                 document.getElementById('resultImage').src = data.image_url;
+            } else {
+                const data = await response.json();
+                document.getElementById('resultImage').src = '';
+                errorDiv.textContent = data.error || 'Erreur inconnue';
             }
         });
     </script>

--- a/test_app.py
+++ b/test_app.py
@@ -2,12 +2,13 @@ import types
 import unittest
 from unittest.mock import patch
 
-from app import app
+from app import app, openai
 
 class GenerateEndpointTestCase(unittest.TestCase):
     def setUp(self):
         self.client = app.test_client()
         app.testing = True
+        openai.api_key = "test"
 
     @patch('app.openai.ChatCompletion.create')
     def test_generate_endpoint(self, mock_create):


### PR DESCRIPTION
## Summary
- improve `/generate-image` endpoint with logging and error checks
- display errors in the HTML page when image generation fails
- adapt tests for updated logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d08e00918832aa5d21a992b439be1